### PR TITLE
JDK-8276447 Deprecate finalization-related methods for removal

### DIFF
--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -276,9 +276,9 @@ public abstract class Enum<E extends Enum<E>>
     /**
      * enum classes cannot have finalize methods.
      * 
-     * @deprecated The finalization mechanism is inherently problematic, and
-     * will be removed in a future release.  See {@link java.lang.Object#finalize}
-     * for details.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      */
     @Deprecated(since="9", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -280,7 +280,7 @@ public abstract class Enum<E extends Enum<E>>
      * {@link java.lang.Object#finalize} for background information and details
      * about migration options.
      */
-    @Deprecated(since="9", forRemoval=true)
+    @Deprecated(since="18", forRemoval=true)
     @SuppressWarnings("removal")
     protected final void finalize() { }
 

--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -275,8 +275,13 @@ public abstract class Enum<E extends Enum<E>>
 
     /**
      * enum classes cannot have finalize methods.
+     * 
+     * @deprecated The finalization mechanism is inherently problematic, and
+     * will be removed in a future release.  See {@link java.lang.Object#finalize}
+     * for details.
      */
-    @SuppressWarnings("deprecation")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     protected final void finalize() { }
 
     /**

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -478,6 +478,11 @@ public class Object {
      * A subclass overrides the {@code finalize} method to dispose of
      * system resources or to perform other cleanup.
      * <p>
+     * When running in a JVM in which finalization has been disabled or removed,
+     * the garbage collector will never call {@code finalize()}. In a JVM in
+     * which finalization is enabled, the GC might call {@code finalize} only
+     * after an indefinite delay.
+     * <p>
      * The general contract of {@code finalize} is that it is invoked
      * if and when the Java virtual
      * machine has determined that there is no longer any
@@ -548,15 +553,15 @@ public class Object {
      * and reliability. See <a href="https://openjdk.java.net/jeps/421">JEP 421</a>
      * for discussion and alternatives.
      * <p>
-     * Classes whose instances hold non-heap resources should provide a method
-     * to enable explicit release of those resources, and they should also
-     * implement {@link AutoCloseable} if appropriate.
-     * {@link java.lang.ref.Cleaner} and {@link java.lang.ref.PhantomReference}
-     * provide more flexible and efficient ways to release resources when an object
-     * becomes unreachable.
+     * Subclasses that override {@code finalize} in order to perform cleanup
+     * should be modified to use alternative cleanup mechanisms and to remove
+     * the overriding {@code finalize} method.
+     * {@link java.lang.ref.Cleaner} and
+     * {@link java.lang.ref.PhantomReference} provide ways to release resources
+     * when an object becomes unreachable. Or, add a {@code close()} method to
+     * explicitly release resources, and implement {@code AutoCloseable} to
+     * enable the object to be used with a {@code try}-with-resources statement.
      * <p>
-     * When running in a JVM in which finalization has been disabled or removed,
-     * the garbage collector will never schedule {@code finalize()} to be called.
      * This method will remain in place until finalizers have been removed from
      * most existing code.
      * 

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -553,14 +553,14 @@ public class Object {
      * and reliability. See <a href="https://openjdk.java.net/jeps/421">JEP 421</a>
      * for discussion and alternatives.
      * <p>
-     * Subclasses that override {@code finalize} in order to perform cleanup
-     * should be modified to use alternative cleanup mechanisms and to remove
-     * the overriding {@code finalize} method.
-     * {@link java.lang.ref.Cleaner} and
-     * {@link java.lang.ref.PhantomReference} provide ways to release resources
-     * when an object becomes unreachable. Or, add a {@code close()} method to
-     * explicitly release resources, and implement {@code AutoCloseable} to
-     * enable the object to be used with a {@code try}-with-resources statement.
+     * Subclasses that override {@code finalize} to perform cleanup should use
+     * alternative cleanup mechanisms and remove the {@code finalize} method.
+     * Use {@link java.lang.ref.Cleaner} and
+     * {@link java.lang.ref.PhantomReference} as safer ways to release resources
+     * when an object becomes unreachable. Alternatively, add a {@code close}
+     * method to explicitly release resources, and implement
+     * {@code AutoCloseable} to enable use of the {@code try}-with-resources
+     * statement.
      * <p>
      * This method will remain in place until finalizers have been removed from
      * most existing code.

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -557,9 +557,8 @@ public class Object {
      * <p>
      * When running in a JVM in which finalization has been disabled or removed,
      * the garbage collector will never schedule {@code finalize()} to be called.
-     * <p>
-     * Removal of this method may be delayed until finalizers have been removed
-     * from most existing code.
+     * This method will remain in place until finalizers have been removed from
+     * most existing code.
      * 
      * @throws Throwable the {@code Exception} raised by this method
      * @see java.lang.ref.WeakReference

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -543,18 +543,13 @@ public class Object {
      *     }
      * }</pre>
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     * will be removed in a future release.  At that time, finalize() will no
-     * longer be called by the garbage collector.
-     *
-     * Finalization can lead to performance issues, deadlocks, and hangs.
-     * Errors in finalizers can lead to resource leaks; there is no way to cancel
-     * finalization if it is no longer necessary; and no ordering is specified
-     * among calls to {@code finalize} methods of different objects.
-     * Furthermore, there are no guarantees regarding the timing of finalization.
-     * The {@code finalize} method might be called on a finalizable object
-     * only after an indefinite delay, if at all.
-     *
+     * @deprecated Finalization has been deprecated for removal in a future
+     * release. See <a href="https://openjdk.java.net/jeps/421">JEP 421</a> for
+     * discussion and alternatives.
+     * 
+     * When running in a JVM in which finalization has been disabled or removed,
+     * the garbage collector will never schedule {@code finalize()} to be called.
+     * 
      * Classes whose instances hold non-heap resources should provide a method
      * to enable explicit release of those resources, and they should also
      * implement {@link AutoCloseable} if appropriate.

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -543,7 +543,10 @@ public class Object {
      *     }
      * }</pre>
      *
-     * @deprecated The finalization mechanism is inherently problematic.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     * will be removed in a future release.  At that time, finalize() will no
+     * longer be called by the garbage collector.
+     *
      * Finalization can lead to performance issues, deadlocks, and hangs.
      * Errors in finalizers can lead to resource leaks; there is no way to cancel
      * finalization if it is no longer necessary; and no ordering is specified
@@ -555,7 +558,7 @@ public class Object {
      * Classes whose instances hold non-heap resources should provide a method
      * to enable explicit release of those resources, and they should also
      * implement {@link AutoCloseable} if appropriate.
-     * The {@link java.lang.ref.Cleaner} and {@link java.lang.ref.PhantomReference}
+     * {@link java.lang.ref.Cleaner} and {@link java.lang.ref.PhantomReference}
      * provide more flexible and efficient ways to release resources when an object
      * becomes unreachable.
      *
@@ -564,6 +567,6 @@ public class Object {
      * @see java.lang.ref.PhantomReference
      * @jls 12.6 Finalization of Class Instances
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
     protected void finalize() throws Throwable { }
 }

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -557,7 +557,10 @@ public class Object {
      * <p>
      * When running in a JVM in which finalization has been disabled or removed,
      * the garbage collector will never schedule {@code finalize()} to be called.
-     *
+     * <p>
+     * Removal of this method may be delayed until finalizers have been removed
+     * from most existing code.
+     * 
      * @throws Throwable the {@code Exception} raised by this method
      * @see java.lang.ref.WeakReference
      * @see java.lang.ref.PhantomReference

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -544,18 +544,19 @@ public class Object {
      * }</pre>
      *
      * @deprecated Finalization has been deprecated for removal in a future
-     * release. See <a href="https://openjdk.java.net/jeps/421">JEP 421</a> for
-     * discussion and alternatives.
-     * 
-     * When running in a JVM in which finalization has been disabled or removed,
-     * the garbage collector will never schedule {@code finalize()} to be called.
-     * 
+     * release. Finalization can lead to problems with security, performance,
+     * and reliability. See <a href="https://openjdk.java.net/jeps/421">JEP 421</a>
+     * for discussion and alternatives.
+     * <p>
      * Classes whose instances hold non-heap resources should provide a method
      * to enable explicit release of those resources, and they should also
      * implement {@link AutoCloseable} if appropriate.
      * {@link java.lang.ref.Cleaner} and {@link java.lang.ref.PhantomReference}
      * provide more flexible and efficient ways to release resources when an object
      * becomes unreachable.
+     * <p>
+     * When running in a JVM in which finalization has been disabled or removed,
+     * the garbage collector will never schedule {@code finalize()} to be called.
      *
      * @throws Throwable the {@code Exception} raised by this method
      * @see java.lang.ref.WeakReference

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -478,10 +478,11 @@ public class Object {
      * A subclass overrides the {@code finalize} method to dispose of
      * system resources or to perform other cleanup.
      * <p>
-     * When running in a JVM in which finalization has been disabled or removed,
-     * the garbage collector will never call {@code finalize()}. In a JVM in
-     * which finalization is enabled, the GC might call {@code finalize} only
-     * after an indefinite delay.
+     * <b>When running in a Java virtual machine in which finalization has been
+     * disabled or removed, the garbage collector will never call
+     * {@code finalize()}. In a Java virtual machine in which finalization is
+     * enabled, the garbage collector might call {@code finalize} only after an
+     * indefinite delay.</b>
      * <p>
      * The general contract of {@code finalize} is that it is invoked
      * if and when the Java virtual
@@ -548,10 +549,11 @@ public class Object {
      *     }
      * }</pre>
      *
-     * @deprecated Finalization has been deprecated for removal in a future
-     * release. Finalization can lead to problems with security, performance,
-     * and reliability. See <a href="https://openjdk.java.net/jeps/421">JEP 421</a>
-     * for discussion and alternatives.
+     * @deprecated Finalization is deprecated and subject to removal in a future
+     * release. The use of finalization can lead to problems with security,
+     * performance, and reliability.
+     * See <a href="https://openjdk.java.net/jeps/421">JEP 421</a> for
+     * discussion and alternatives.
      * <p>
      * Subclasses that override {@code finalize} to perform cleanup should use
      * alternative cleanup mechanisms and remove the {@code finalize} method.

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -686,8 +686,13 @@ public class Runtime {
      * The method {@link System#runFinalization()} is the conventional
      * and convenient means of invoking this method.
      *
+     * @deprecated The finalization mechanism is inherently problematic, and
+     * will be removed in a future release.  See {@link java.lang.Object#finalize}
+     * for details.
+     * 
      * @see     java.lang.Object#finalize()
      */
+    @Deprecated(since="18", forRemoval=true)
     public void runFinalization() {
         SharedSecrets.getJavaLangRefAccess().runFinalization();
     }

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -689,7 +689,10 @@ public class Runtime {
      * @deprecated Finalization has been deprecated for removal.  See
      * {@link java.lang.Object#finalize} for background information and details
      * about migration options.
-     * 
+     * <p>
+     * When running in a JVM in which finalization has been disabled or removed,
+     * no objects will be pending finalization, so this method does nothing.
+     *
      * @see     java.lang.Object#finalize()
      */
     @Deprecated(since="18", forRemoval=true)

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -694,6 +694,7 @@ public class Runtime {
      * no objects will be pending finalization, so this method does nothing.
      *
      * @see     java.lang.Object#finalize()
+     * @jls 12.6 Finalization of Class Instances
      */
     @Deprecated(since="18", forRemoval=true)
     public void runFinalization() {

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -686,9 +686,9 @@ public class Runtime {
      * The method {@link System#runFinalization()} is the conventional
      * and convenient means of invoking this method.
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     * will be removed in a future release.  See {@link java.lang.Object#finalize}
-     * for details.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      * 
      * @see     java.lang.Object#finalize()
      */

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1917,8 +1917,14 @@ public final class System {
      * Runtime.getRuntime().runFinalization()
      * </pre></blockquote>
      *
+     * @deprecated The finalization mechanism is inherently problematic, and
+     * will be removed in a future release.  See {@link java.lang.Object#finalize}
+     * for details.
+     * 
      * @see     java.lang.Runtime#runFinalization()
      */
+    @Deprecated(since="18", forRemoval=true)
+    @SuppressWarnings("removal")
     public static void runFinalization() {
         Runtime.getRuntime().runFinalization();
     }
@@ -2303,7 +2309,7 @@ public final class System {
             public Thread newThreadWithAcc(Runnable target, @SuppressWarnings("removal") AccessControlContext acc) {
                 return new Thread(target, acc);
             }
-            @SuppressWarnings("deprecation")
+            @SuppressWarnings("removal")
             public void invokeFinalize(Object o) throws Throwable {
                 o.finalize();
             }

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1920,7 +1920,10 @@ public final class System {
      * @deprecated Finalization has been deprecated for removal.  See
      * {@link java.lang.Object#finalize} for background information and details
      * about migration options.
-     * 
+     * <p>
+     * When running in a JVM in which finalization has been disabled or removed,
+     * no objects will be pending finalization, so this method does nothing.
+     *
      * @see     java.lang.Runtime#runFinalization()
      */
     @Deprecated(since="18", forRemoval=true)

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1917,9 +1917,9 @@ public final class System {
      * Runtime.getRuntime().runFinalization()
      * </pre></blockquote>
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     * will be removed in a future release.  See {@link java.lang.Object#finalize}
-     * for details.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      * 
      * @see     java.lang.Runtime#runFinalization()
      */

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1925,6 +1925,7 @@ public final class System {
      * no objects will be pending finalization, so this method does nothing.
      *
      * @see     java.lang.Runtime#runFinalization()
+     * @jls 12.6 Finalization of Class Instances
      */
     @Deprecated(since="18", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.base/share/classes/java/util/concurrent/Executors.java
+++ b/src/java.base/share/classes/java/util/concurrent/Executors.java
@@ -791,7 +791,7 @@ public class Executors {
         FinalizableDelegatedExecutorService(ExecutorService executor) {
             super(executor);
         }
-        @SuppressWarnings("deprecation")
+        @SuppressWarnings("removal")
         protected void finalize() {
             super.shutdown();
         }

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1478,9 +1478,9 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * that shut down this executor, but in this version, finalize
      * does nothing.
      * 
-     * @deprecated The finalization mechanism is inherently problematic, and
-     * will be removed in a future release.  See {@link java.lang.Object#finalize}
-     * for details.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      */
     @Deprecated(since="9", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1477,8 +1477,13 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @implNote Previous versions of this class had a finalize method
      * that shut down this executor, but in this version, finalize
      * does nothing.
+     * 
+     * @deprecated The finalization mechanism is inherently problematic, and
+     * will be removed in a future release.  See {@link java.lang.Object#finalize}
+     * for details.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     protected void finalize() {}
 
     /**

--- a/src/java.base/share/classes/sun/net/www/MeteredStream.java
+++ b/src/java.base/share/classes/sun/net/www/MeteredStream.java
@@ -242,7 +242,7 @@ public class MeteredStream extends FilterInputStream {
         return readLock.isHeldByCurrentThread();
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         try {
             close();

--- a/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
@@ -270,7 +270,7 @@ abstract class BaseSSLSocketImpl extends SSLSocket {
      * the penalty of prematurly killing SSL sessions.
      */
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected final void finalize() throws Throwable {
         try {
             close();

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIControl.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIControl.java
@@ -114,7 +114,7 @@ public final class JRSUIControl {
         changes.putAll(other.changes);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected synchronized void finalize() throws Throwable {
         if (cfDictionaryPtr == 0) return;
         disposeCFDictionary(cfDictionaryPtr);

--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsEnvironment.java
@@ -144,7 +144,7 @@ public final class CGraphicsEnvironment extends SunGraphicsEnvironment {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         try {
             super.finalize();

--- a/src/java.desktop/macosx/classes/sun/font/CFont.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFont.java
@@ -247,7 +247,7 @@ public final class CFont extends PhysicalFont implements FontSubstitution {
         return compFont;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected synchronized void finalize() {
         if (nativeFontPtr != 0) {
             disposeNativeFont(nativeFontPtr);

--- a/src/java.desktop/macosx/classes/sun/font/CStrike.java
+++ b/src/java.desktop/macosx/classes/sun/font/CStrike.java
@@ -125,7 +125,7 @@ public final class CStrike extends PhysicalStrike {
         return nativeStrikePtr;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected synchronized void finalize() throws Throwable {
         if (nativeStrikePtr != 0) {
             disposeNativeStrikePtr(nativeStrikePtr);

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CFRetainedResource.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CFRetainedResource.java
@@ -163,7 +163,7 @@ public class CFRetainedResource {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected final void finalize() throws Throwable {
         dispose();
     }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -598,7 +598,7 @@ public final class CPrinterJob extends RasterPrinterJob {
     // The following methods are CPrinterJob specific.
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         synchronized (fNSPrintInfoLock) {
             if (fNSPrintInfo != -1) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SubImageInputStream.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SubImageInputStream.java
@@ -72,7 +72,7 @@ public final class SubImageInputStream extends ImageInputStreamImpl {
         streamPos = pos;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         // Empty finalizer (for improved performance; no need to call
         // super.finalize() in this case)

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageWriter.java
@@ -147,7 +147,7 @@ final class ChunkStream extends ImageOutputStreamImpl {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         // Empty finalizer (for improved performance; no need to call
         // super.finalize() in this case)
@@ -284,7 +284,7 @@ final class IDATOutputStream extends ImageOutputStreamImpl {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         // Empty finalizer (for improved performance; no need to call
         // super.finalize() in this case)

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFBaseJPEGCompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFBaseJPEGCompressor.java
@@ -435,7 +435,7 @@ public abstract class TIFFBaseJPEGCompressor extends TIFFCompressor {
         return compDataLength;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         super.finalize();
         if(JPEGWriter != null) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFJPEGDecompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFJPEGDecompressor.java
@@ -139,7 +139,7 @@ public class TIFFJPEGDecompressor extends TIFFDecompressor {
         JPEGReader.read(0, JPEGParam);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         super.finalize();
         JPEGReader.dispose();

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFOldJPEGDecompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFOldJPEGDecompressor.java
@@ -610,7 +610,7 @@ public class TIFFOldJPEGDecompressor extends TIFFJPEGDecompressor {
         JPEGReader.read(0, JPEGParam);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         super.finalize();
         JPEGReader.dispose();

--- a/src/java.desktop/share/classes/com/sun/imageio/stream/StreamFinalizer.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/stream/StreamFinalizer.java
@@ -60,7 +60,7 @@ public class StreamFinalizer {
         this.stream = stream;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         try {
             stream.close();

--- a/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
@@ -425,7 +425,7 @@ abstract class AbstractMidiDevice implements MidiDevice, ReferenceCountingDevice
      * close this device if discarded by the garbage collector.
      */
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected final void finalize() {
         close();
     }

--- a/src/java.desktop/share/classes/com/sun/media/sound/JavaSoundAudioClip.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/JavaSoundAudioClip.java
@@ -283,6 +283,7 @@ public final class JavaSoundAudioClip implements AudioClip, MetaEventListener, L
     }
 
     @Override
+    @SuppressWarnings("removal")
     protected void finalize() {
 
         if (clip != null) {

--- a/src/java.desktop/share/classes/java/awt/Graphics.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics.java
@@ -1162,7 +1162,11 @@ public abstract class Graphics {
     /**
      * Disposes of this graphics context once it is no longer referenced.
      *
-     * @deprecated The {@code finalize} method has been deprecated.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
+     *     for details.
+     * 
+     *     The {@code finalize} method has been deprecated.
      *     Subclasses that override {@code finalize} in order to perform cleanup
      *     should be modified to use alternative cleanup mechanisms and
      *     to remove the overriding {@code finalize} method.
@@ -1172,7 +1176,8 @@ public abstract class Graphics {
      *     information about migration options.
      * @see #dispose
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     public void finalize() {
         dispose();
     }

--- a/src/java.desktop/share/classes/java/awt/Graphics.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics.java
@@ -1162,18 +1162,10 @@ public abstract class Graphics {
     /**
      * Disposes of this graphics context once it is no longer referenced.
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
-     *     for details.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      * 
-     *     The {@code finalize} method has been deprecated.
-     *     Subclasses that override {@code finalize} in order to perform cleanup
-     *     should be modified to use alternative cleanup mechanisms and
-     *     to remove the overriding {@code finalize} method.
-     *     When overriding the {@code finalize} method, its implementation must explicitly
-     *     ensure that {@code super.finalize()} is invoked as described in {@link Object#finalize}.
-     *     See the specification for {@link Object#finalize()} for further
-     *     information about migration options.
      * @see #dispose
      */
     @Deprecated(since="9", forRemoval=true)

--- a/src/java.desktop/share/classes/java/awt/PrintJob.java
+++ b/src/java.desktop/share/classes/java/awt/PrintJob.java
@@ -85,18 +85,10 @@ public abstract class PrintJob {
     /**
      * Ends this print job once it is no longer referenced.
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
-     *     for details.
-     * 
-     *     The {@code finalize} method has been deprecated.
-     *     Subclasses that override {@code finalize} in order to perform cleanup
-     *     should be modified to use alternative cleanup mechanisms and
-     *     to remove the overriding {@code finalize} method.
-     *     When overriding the {@code finalize} method, its implementation must explicitly
-     *     ensure that {@code super.finalize()} is invoked as described in {@link Object#finalize}.
-     *     See the specification for {@link Object#finalize()} for further
-     *     information about migration options.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
+     *
      * @see #end
      */
     @Deprecated(since="9", forRemoval=true)

--- a/src/java.desktop/share/classes/java/awt/PrintJob.java
+++ b/src/java.desktop/share/classes/java/awt/PrintJob.java
@@ -85,7 +85,11 @@ public abstract class PrintJob {
     /**
      * Ends this print job once it is no longer referenced.
      *
-     * @deprecated The {@code finalize} method has been deprecated.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
+     *     for details.
+     * 
+     *     The {@code finalize} method has been deprecated.
      *     Subclasses that override {@code finalize} in order to perform cleanup
      *     should be modified to use alternative cleanup mechanisms and
      *     to remove the overriding {@code finalize} method.
@@ -95,7 +99,8 @@ public abstract class PrintJob {
      *     information about migration options.
      * @see #end
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     public void finalize() {
         end();
     }

--- a/src/java.desktop/share/classes/javax/imageio/spi/ServiceRegistry.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ServiceRegistry.java
@@ -680,18 +680,9 @@ public class ServiceRegistry {
      * @exception Throwable if an error occurs during superclass
      * finalization.
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
-     *     for details.
-     * 
-     *     The {@code finalize} method has been deprecated.
-     *     Subclasses that override {@code finalize} in order to perform cleanup
-     *     should be modified to use alternative cleanup mechanisms and
-     *     to remove the overriding {@code finalize} method.
-     *     When overriding the {@code finalize} method, its implementation must explicitly
-     *     ensure that {@code super.finalize()} is invoked as described in {@link Object#finalize}.
-     *     See the specification for {@link Object#finalize()} for further
-     *     information about migration options.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      */
     @Deprecated(since="9", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.desktop/share/classes/javax/imageio/spi/ServiceRegistry.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ServiceRegistry.java
@@ -680,7 +680,11 @@ public class ServiceRegistry {
      * @exception Throwable if an error occurs during superclass
      * finalization.
      *
-     * @deprecated The {@code finalize} method has been deprecated.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
+     *     for details.
+     * 
+     *     The {@code finalize} method has been deprecated.
      *     Subclasses that override {@code finalize} in order to perform cleanup
      *     should be modified to use alternative cleanup mechanisms and
      *     to remove the overriding {@code finalize} method.
@@ -689,7 +693,8 @@ public class ServiceRegistry {
      *     See the specification for {@link Object#finalize()} for further
      *     information about migration options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     public void finalize() throws Throwable {
         deregisterAll();
         super.finalize();
@@ -842,7 +847,7 @@ class SubRegistry {
         accMap.clear();
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public synchronized void finalize() {
         clear();
     }

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
@@ -261,18 +261,9 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
     /**
      * {@inheritDoc}
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
-     *     for details.
-     * 
-     *     The {@code finalize} method has been deprecated.
-     *     Subclasses that override {@code finalize} in order to perform cleanup
-     *     should be modified to use alternative cleanup mechanisms and
-     *     to remove the overriding {@code finalize} method.
-     *     When overriding the {@code finalize} method, its implementation must explicitly
-     *     ensure that {@code super.finalize()} is invoked as described in {@link Object#finalize}.
-     *     See the specification for {@link Object#finalize()} for further
-     *     information about migration options.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      */
     @Deprecated(since="9", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
@@ -261,7 +261,11 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
     /**
      * {@inheritDoc}
      *
-     * @deprecated The {@code finalize} method has been deprecated.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
+     *     for details.
+     * 
+     *     The {@code finalize} method has been deprecated.
      *     Subclasses that override {@code finalize} in order to perform cleanup
      *     should be modified to use alternative cleanup mechanisms and
      *     to remove the overriding {@code finalize} method.
@@ -270,7 +274,8 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
      *     See the specification for {@link Object#finalize()} for further
      *     information about migration options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         // Empty finalizer: for performance reasons we instead use the
         // Disposer mechanism for ensuring that the underlying

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileImageInputStream.java
@@ -156,7 +156,11 @@ public class FileImageInputStream extends ImageInputStreamImpl {
     /**
      * {@inheritDoc}
      *
-     * @deprecated The {@code finalize} method has been deprecated.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
+     *     for details.
+     * 
+     *     The {@code finalize} method has been deprecated.
      *     Subclasses that override {@code finalize} in order to perform cleanup
      *     should be modified to use alternative cleanup mechanisms and
      *     to remove the overriding {@code finalize} method.
@@ -165,7 +169,8 @@ public class FileImageInputStream extends ImageInputStreamImpl {
      *     See the specification for {@link Object#finalize()} for further
      *     information about migration options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         // Empty finalizer: for performance reasons we instead use the
         // Disposer mechanism for ensuring that the underlying

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileImageInputStream.java
@@ -156,18 +156,9 @@ public class FileImageInputStream extends ImageInputStreamImpl {
     /**
      * {@inheritDoc}
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
-     *     for details.
-     * 
-     *     The {@code finalize} method has been deprecated.
-     *     Subclasses that override {@code finalize} in order to perform cleanup
-     *     should be modified to use alternative cleanup mechanisms and
-     *     to remove the overriding {@code finalize} method.
-     *     When overriding the {@code finalize} method, its implementation must explicitly
-     *     ensure that {@code super.finalize()} is invoked as described in {@link Object#finalize}.
-     *     See the specification for {@link Object#finalize()} for further
-     *     information about migration options.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      */
     @Deprecated(since="9", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileImageOutputStream.java
@@ -164,18 +164,9 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
     /**
      * {@inheritDoc}
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
-     *     for details.
-     * 
-     *     The {@code finalize} method has been deprecated.
-     *     Subclasses that override {@code finalize} in order to perform cleanup
-     *     should be modified to use alternative cleanup mechanisms and
-     *     to remove the overriding {@code finalize} method.
-     *     When overriding the {@code finalize} method, its implementation must explicitly
-     *     ensure that {@code super.finalize()} is invoked as described in {@link Object#finalize}.
-     *     See the specification for {@link Object#finalize()} for further
-     *     information about migration options.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      */
     @Deprecated(since="9", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileImageOutputStream.java
@@ -164,7 +164,11 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
     /**
      * {@inheritDoc}
      *
-     * @deprecated The {@code finalize} method has been deprecated.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
+     *     for details.
+     * 
+     *     The {@code finalize} method has been deprecated.
      *     Subclasses that override {@code finalize} in order to perform cleanup
      *     should be modified to use alternative cleanup mechanisms and
      *     to remove the overriding {@code finalize} method.
@@ -173,7 +177,8 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
      *     See the specification for {@link Object#finalize()} for further
      *     information about migration options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         // Empty finalizer: for performance reasons we instead use the
         // Disposer mechanism for ensuring that the underlying

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
@@ -868,7 +868,11 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * @exception Throwable if an error occurs during superclass
      * finalization.
      *
-     * @deprecated The {@code finalize} method has been deprecated.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
+     *     for details.
+     * 
+     *     The {@code finalize} method has been deprecated.
      *     Subclasses that override {@code finalize} in order to perform cleanup
      *     should be modified to use alternative cleanup mechanisms and
      *     to remove the overriding {@code finalize} method.
@@ -877,7 +881,8 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      *     See the specification for {@link Object#finalize()} for further
      *     information about migration options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         if (!isClosed) {
             try {

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
@@ -868,18 +868,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * @exception Throwable if an error occurs during superclass
      * finalization.
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
-     *     for details.
-     * 
-     *     The {@code finalize} method has been deprecated.
-     *     Subclasses that override {@code finalize} in order to perform cleanup
-     *     should be modified to use alternative cleanup mechanisms and
-     *     to remove the overriding {@code finalize} method.
-     *     When overriding the {@code finalize} method, its implementation must explicitly
-     *     ensure that {@code super.finalize()} is invoked as described in {@link Object#finalize}.
-     *     See the specification for {@link Object#finalize()} for further
-     *     information about migration options.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      */
     @Deprecated(since="9", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageInputStream.java
@@ -179,18 +179,9 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
     /**
      * {@inheritDoc}
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
-     *     for details.
-     * 
-     *     The {@code finalize} method has been deprecated.
-     *     Subclasses that override {@code finalize} in order to perform cleanup
-     *     should be modified to use alternative cleanup mechanisms and
-     *     to remove the overriding {@code finalize} method.
-     *     When overriding the {@code finalize} method, its implementation must explicitly
-     *     ensure that {@code super.finalize()} is invoked as described in {@link Object#finalize}.
-     *     See the specification for {@link Object#finalize()} for further
-     *     information about migration options.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
      */
     @Deprecated(since="9", forRemoval=true)
     @SuppressWarnings("removal")

--- a/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageInputStream.java
@@ -179,7 +179,11 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
     /**
      * {@inheritDoc}
      *
-     * @deprecated The {@code finalize} method has been deprecated.
+     * @deprecated The finalization mechanism is inherently problematic, and
+     *     will be removed in a future release.  See {@link java.lang.Object#finalize}
+     *     for details.
+     * 
+     *     The {@code finalize} method has been deprecated.
      *     Subclasses that override {@code finalize} in order to perform cleanup
      *     should be modified to use alternative cleanup mechanisms and
      *     to remove the overriding {@code finalize} method.
@@ -188,7 +192,8 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
      *     See the specification for {@link Object#finalize()} for further
      *     information about migration options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         // Empty finalizer: for performance reasons we instead use the
         // Disposer mechanism for ensuring that the underlying

--- a/src/java.desktop/share/classes/javax/swing/text/StringContent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/StringContent.java
@@ -351,7 +351,7 @@ public final class StringContent implements AbstractDocument.Content, Serializab
             return rec.offset;
         }
 
-        @SuppressWarnings("deprecation")
+        @SuppressWarnings("removal")
         protected void finalize() throws Throwable {
             // schedule the record to be removed later
             // on another thread.

--- a/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java
+++ b/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java
@@ -3656,7 +3656,7 @@ public final class SunGraphics2D
      * enough to know that if our override is empty then it should not
      * mark us as finalizeable.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public void finalize() {
         // DO NOT REMOVE THIS METHOD
     }

--- a/src/java.desktop/share/classes/sun/print/PeekGraphics.java
+++ b/src/java.desktop/share/classes/sun/print/PeekGraphics.java
@@ -1336,7 +1336,7 @@ public class PeekGraphics extends Graphics2D
     /**
      * Empty finalizer as no clean up needed here.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public void finalize() {
     }
 

--- a/src/java.desktop/share/classes/sun/print/PrintJob2D.java
+++ b/src/java.desktop/share/classes/sun/print/PrintJob2D.java
@@ -944,7 +944,7 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
      * Ends this print job once it is no longer referenced.
      * @see #end
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public void finalize() {
         end();
     }

--- a/src/java.desktop/share/classes/sun/print/ProxyGraphics.java
+++ b/src/java.desktop/share/classes/sun/print/ProxyGraphics.java
@@ -1099,7 +1099,7 @@ public class ProxyGraphics extends Graphics {
     /**
      * Empty finalizer as no clean up needed here.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public void finalize() {
     }
 

--- a/src/java.desktop/share/classes/sun/print/ProxyGraphics2D.java
+++ b/src/java.desktop/share/classes/sun/print/ProxyGraphics2D.java
@@ -1264,7 +1264,7 @@ public class ProxyGraphics2D extends Graphics2D implements PrinterGraphics {
     /**
      * Empty finalizer as no clean up needed here.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public void finalize() {
     }
 

--- a/src/java.desktop/unix/classes/sun/awt/X11InputMethodBase.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11InputMethodBase.java
@@ -172,7 +172,7 @@ public abstract class X11InputMethodBase extends InputMethodAdapter {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         dispose();
         super.finalize();

--- a/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
@@ -133,7 +133,7 @@ final class WInputMethod extends InputMethodAdapter
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable
     {
         // Release the resources used by the native input context.

--- a/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -207,9 +207,14 @@ public interface MemoryMXBean extends PlatformManagedObject {
      * Returns the approximate number of objects for which
      * finalization is pending.
      *
+     * @deprecated The finalization mechanism is inherently problematic, and
+     * will be removed in a future release.  See {@link java.lang.Object#finalize}
+     * for details.
+     * 
      * @return the approximate number objects for which finalization
      * is pending.
      */
+    @Deprecated(since="18")
     public int getObjectPendingFinalizationCount();
 
     /**

--- a/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -207,12 +207,13 @@ public interface MemoryMXBean extends PlatformManagedObject {
      * Returns the approximate number of objects for which
      * finalization is pending.
      *
-     * @deprecated The finalization mechanism is inherently problematic, and
-     * will be removed in a future release.  See {@link java.lang.Object#finalize}
-     * for details.
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for details.
      * 
      * @return the approximate number objects for which finalization
-     * is pending.
+     * is pending. If this MemoryMXBean contains information about a JVM in
+     * which finalization has been disabled or removed, this method always
+     * returns zero.
      */
     @Deprecated(since="18")
     public int getObjectPendingFinalizationCount();

--- a/src/java.management/share/classes/sun/management/MemoryImpl.java
+++ b/src/java.management/share/classes/sun/management/MemoryImpl.java
@@ -58,6 +58,7 @@ class MemoryImpl extends NotificationEmitterSupport
         this.jvm = vm;
     }
 
+    @SuppressWarnings("removal")
     public int getObjectPendingFinalizationCount() {
         return jdk.internal.misc.VM.getFinalRefCount();
     }

--- a/src/java.management/share/classes/sun/management/MemoryImpl.java
+++ b/src/java.management/share/classes/sun/management/MemoryImpl.java
@@ -58,7 +58,7 @@ class MemoryImpl extends NotificationEmitterSupport
         this.jvm = vm;
     }
 
-    @SuppressWarnings("removal")
+    @SuppressWarnings("deprecation")
     public int getObjectPendingFinalizationCount() {
         return jdk.internal.misc.VM.getFinalRefCount();
     }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/AbstractLdapNamingEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/AbstractLdapNamingEnumeration.java
@@ -383,7 +383,7 @@ abstract class AbstractLdapNamingEnumeration<T extends NameClassPair>
         listArg = ne.listArg;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected final void finalize() {
         cleanup();
     }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
@@ -477,7 +477,7 @@ public final class LdapClient implements PooledConnection {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         if (debug > 0) System.err.println("LdapClient: finalize " + this);
         forceClose(pooled);

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtx.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtx.java
@@ -2639,7 +2639,7 @@ public final class LdapCtx extends ComponentDirContext
 
    // ----------------- Connection  ---------------------
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         try {
             close();

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/DefaultCallbackHandler.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/DefaultCallbackHandler.java
@@ -131,7 +131,7 @@ final class DefaultCallbackHandler implements CallbackHandler {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         clearPassword();
     }

--- a/src/java.rmi/share/classes/sun/rmi/log/LogInputStream.java
+++ b/src/java.rmi/share/classes/sun/rmi/log/LogInputStream.java
@@ -128,7 +128,7 @@ class LogInputStream extends InputStream {
     /**
      * Closes the stream when garbage is collected.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws IOException {
         close();
     }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSCredElement.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSCredElement.java
@@ -132,7 +132,7 @@ public class GSSCredElement implements GSSCredentialSpi {
         return "N/A";
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         dispose();
     }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSNameElement.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSNameElement.java
@@ -290,7 +290,7 @@ public class GSSNameElement implements GSSNameSpi {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         dispose();
     }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/NativeGSSContext.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/NativeGSSContext.java
@@ -639,7 +639,7 @@ class NativeGSSContext implements GSSContextSpi {
         return isInitiator;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         dispose();
     }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Base.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Base.java
@@ -136,7 +136,7 @@ abstract class CramMD5Base {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         clearPassword();
     }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/PlainClient.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/PlainClient.java
@@ -195,7 +195,7 @@ final class PlainClient implements SaslClient {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         clearPassword();
     }

--- a/src/java.smartcardio/share/classes/sun/security/smartcardio/CardImpl.java
+++ b/src/java.smartcardio/share/classes/sun/security/smartcardio/CardImpl.java
@@ -276,7 +276,7 @@ final class CardImpl extends Card {
             + ", protocol " + getProtocol() + ", state " + state;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         try {
             if (state == State.OK) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -243,7 +243,7 @@ final class P11KeyStore extends KeyStoreSpi {
             pc.setPassword(password);  // this clones the password if not null
         }
 
-        @SuppressWarnings("deprecation")
+        @SuppressWarnings("removal")
         protected void finalize() throws Throwable {
             if (password != null) {
                 Arrays.fill(password, ' ');

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -1615,7 +1615,7 @@ public class PKCS11 {
      *
      * @exception Throwable If finalization fails.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         disconnect();
     }

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKey.java
@@ -55,7 +55,7 @@ abstract class CKey implements Key, Length {
             this.hCryptKey = hCryptKey;
         }
 
-        @SuppressWarnings("deprecation")
+        @SuppressWarnings("removal")
         protected void finalize() throws Throwable {
             try {
                 synchronized(this) {

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/SummaryTab.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/SummaryTab.java
@@ -113,7 +113,7 @@ class SummaryTab extends Tab {
 
     StringBuilder buf;
 
-    @SuppressWarnings({"removal", "deprecation"})
+    @SuppressWarnings("deprecation")
     synchronized Result formatSummary() {
         Result result = new Result();
         ProxyClient proxyClient = vmPanel.getProxyClient();
@@ -216,7 +216,6 @@ class SummaryTab extends Tab {
                 append(Messages.COMMITTED_MEMORY,  strings2[0]);
                 append(Messages.SUMMARY_TAB_PENDING_FINALIZATION_LABEL,
                        Resources.format(Messages.SUMMARY_TAB_PENDING_FINALIZATION_VALUE,
-// fix me - deprecated
                                         memoryBean.getObjectPendingFinalizationCount()));
                 append(endTable);
 

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/SummaryTab.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/SummaryTab.java
@@ -113,7 +113,7 @@ class SummaryTab extends Tab {
 
     StringBuilder buf;
 
-    @SuppressWarnings("removal")
+    @SuppressWarnings({"removal", "deprecation"})
     synchronized Result formatSummary() {
         Result result = new Result();
         ProxyClient proxyClient = vmPanel.getProxyClient();
@@ -216,6 +216,7 @@ class SummaryTab extends Tab {
                 append(Messages.COMMITTED_MEMORY,  strings2[0]);
                 append(Messages.SUMMARY_TAB_PENDING_FINALIZATION_LABEL,
                        Resources.format(Messages.SUMMARY_TAB_PENDING_FINALIZATION_VALUE,
+// fix me - deprecated
                                         memoryBean.getObjectPendingFinalizationCount()));
                 append(endTable);
 

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/SummaryTab.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/SummaryTab.java
@@ -113,6 +113,7 @@ class SummaryTab extends Tab {
 
     StringBuilder buf;
 
+    @SuppressWarnings("removal")
     synchronized Result formatSummary() {
         Result result = new Result();
         ProxyClient proxyClient = vmPanel.getProxyClient();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
@@ -112,7 +112,7 @@ final class ChunkInputStream extends InputStream {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         super.finalize();
         close();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunksChannel.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunksChannel.java
@@ -137,7 +137,7 @@ final class ChunksChannel implements ReadableByteChannel {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         super.finalize();
         close();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
@@ -134,7 +134,7 @@ final class RepositoryChunk {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         boolean destroy = false;
         synchronized (this) {

--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
@@ -148,7 +148,7 @@ public class DnsClient {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         close();
     }

--- a/src/jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContext.java
+++ b/src/jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContext.java
@@ -120,7 +120,7 @@ public class RegistryContext implements Context, Referenceable {
         reference = ctx.reference;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         close();
     }
@@ -596,7 +596,7 @@ class BindingEnumeration implements NamingEnumeration<Binding> {
         nextName = 0;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() {
         ctx.close();
     }

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Base.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Base.java
@@ -162,7 +162,7 @@ abstract class GssKrb5Base extends AbstractSaslImpl {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         dispose();
     }

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1219,7 +1219,7 @@ class ZipFileSystem extends FileSystem {
         return zc.toString(name);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     protected void finalize() throws IOException {
         close();
     }


### PR DESCRIPTION
Here are the code changes for the "Deprecate finalizers in the standard Java API" portion of [JEP 421](https://openjdk.java.net/jeps/421) ("Deprecate Finalization for Removal") for code review.

This change makes the indicated deprecations, and updates the API spec for JEP 421. It also updates the relevant `@SuppressWarning` annotations.

The [CSR](https://bugs.openjdk.java.net/browse/JDK-8276748) has been approved.
An automated test build+test run passes cleanly (FWIW :D ).

