### PR TITLE
8314480: Memory ordering spec updates in java.lang.ref

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -215,13 +215,13 @@ public final class Cleaner {
      * Refer to the <a href="#compatible-cleaners">API Note</a> above for
      * cautions about the behavior of cleaning actions.
      *
-     * The object being registered remains reachable (and therefore not eligible
+     * <p>The object being registered remains reachable (and therefore not eligible
      * for cleaning) during the register() method.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling
      * Cleaner.register()
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * the Cleaner runs the registered cleaning action.
+     * the cleaning action is run by the Cleaner's thread.
      *
      * @param obj   the object to monitor
      * @param action a {@code Runnable} to invoke when the object becomes phantom reachable

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -215,6 +215,14 @@ public final class Cleaner {
      * Refer to the <a href="#compatible-cleaners">API Note</a> above for
      * cautions about the behavior of cleaning actions.
      *
+     * The object being registered remains reachable (and therefore not eligible
+     * for cleaning) during the register() method.
+     *
+     * <p>Memory consistency effects: Actions in a thread prior to calling
+     * Cleaner.register()
+     * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
+     * the Cleaner runs the registered cleaning action.
+     *
      * @param obj   the object to monitor
      * @param action a {@code Runnable} to invoke when the object becomes phantom reachable
      * @return a {@code Cleanable} instance

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -215,7 +215,7 @@ public final class Cleaner {
      * Refer to the <a href="#compatible-cleaners">API Note</a> above for
      * cautions about the behavior of cleaning actions.
      *
-     * <p>The object being registered remains reachable (and therefore not eligible
+     * <p>The object being registered is kept strongly-reachable (and therefore not eligible
      * for cleaning) during the register() method.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -214,7 +214,7 @@ public final class Cleaner {
      * Refer to the <a href="#compatible-cleaners">API Note</a> above for
      * cautions about the behavior of cleaning actions.
      *
-     * <p>The object being registered remains reachable (and therefore not eligible
+     * <p>The object being registered is kept strongly-reachable (and therefore not eligible
      * for cleaning) during the register() method.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -214,13 +214,13 @@ public final class Cleaner {
      * Refer to the <a href="#compatible-cleaners">API Note</a> above for
      * cautions about the behavior of cleaning actions.
      *
-     * The object being registered remains reachable (and therefore not eligible
+     * <p>The object being registered remains reachable (and therefore not eligible
      * for cleaning) during the register() method.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling
      * Cleaner.register()
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * the Cleaner runs the registered cleaning action.
+     * the cleaning action is run by the Cleaner's thread.
      *
      * @param obj   the object to monitor
      * @param action a {@code Runnable} to invoke when the object becomes phantom reachable

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -214,6 +214,14 @@ public final class Cleaner {
      * Refer to the <a href="#compatible-cleaners">API Note</a> above for
      * cautions about the behavior of cleaning actions.
      *
+     * The object being registered remains reachable (and therefore not eligible
+     * for cleaning) during the register() method.
+     *
+     * <p>Memory consistency effects: Actions in a thread prior to calling
+     * Cleaner.register()
+     * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
+     * the Cleaner runs the registered cleaning action.
+     *
      * @param obj   the object to monitor
      * @param action a {@code Runnable} to invoke when the object becomes phantom reachable
      * @return a {@code Cleanable} instance

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -476,6 +476,12 @@ public abstract sealed class Reference<T>
      * <p> This method is invoked only by Java code; when the garbage collector
      * enqueues references it does so directly, without invoking this method.
      *
+     * <p>Memory consistency effects: Actions in a thread prior to successfully
+     * enqueueing a reference on a queue
+     * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
+     * the reference is removed from the queue by {@link ReferenceQueue#poll}
+     * or {@link ReferenceQueue#remove}.
+     *
      * @return   {@code true} if this reference object was successfully
      *           enqueued; {@code false} if it was already enqueued or if
      *           it was not registered with a queue when it was created
@@ -513,7 +519,7 @@ public abstract sealed class Reference<T>
     /**
      * Ensures that the given object remains
      * <a href="package-summary.html#reachability"><em>strongly reachable</em></a>,
-     * regardless of any prior actions of the program that might otherwise cause
+     * regardless of any other actions of the program that might otherwise cause
      * the object to become unreachable; thus, the object is not
      * reclaimable by garbage collection at least until after the invocation of
      * this method. {@link Reference}s referring to the given object will not be
@@ -524,16 +530,14 @@ public abstract sealed class Reference<T>
      * <p> This method establishes an ordering for <em>strong reachability</em>
      * with respect to garbage collection.  It controls relations that are
      * otherwise only implicit in a program -- the reachability conditions
-     * triggering garbage collection.  This method is designed for use
+     * triggering garbage collection.  This method is applicable only
      * when reclamation may have visible effects,
      * such as for objects with finalizers or that use Cleaner.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling
      * reachabilityFence(x)
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * any Reference to x is enqueued on a ReferenceQueue (as happens when a
-     * {@linkplain Cleaner#register cleaning action} for x runs on a
-     * {@linkplain Cleaner}'s thread).
+     * the garbage collector enqueues any Reference to x on a ReferenceQueue.
      *
      * @apiNote
      * Reference processing or finalization may occur whenever the virtual machine detects that no

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -511,13 +511,15 @@ public abstract sealed class Reference<T>
     }
 
     /**
-     * Ensures that the object referenced by the given reference remains
+     * Ensures that the given object remains
      * <a href="package-summary.html#reachability"><em>strongly reachable</em></a>,
      * regardless of any prior actions of the program that might otherwise cause
-     * the object to become unreachable; thus, the referenced object is not
+     * the object to become unreachable; thus, the object is not
      * reclaimable by garbage collection at least until after the invocation of
-     * this method.  Invocation of this method does not itself initiate garbage
-     * collection or finalization.
+     * this method. {@link Reference}s referring to the given object will not be
+     * enqueued on a {@link ReferenceQueue} until after invocation of this method.
+     * Invocation of this method does not itself initiate garbage collection or
+     * finalization.
      *
      * <p> This method establishes an ordering for <em>strong reachability</em>
      * with respect to garbage collection.  It controls relations that are
@@ -527,13 +529,15 @@ public abstract sealed class Reference<T>
      * {@code synchronized} blocks or methods, or using other synchronization
      * facilities are not possible or do not provide the desired control.  This
      * method is applicable only when reclamation may have visible effects,
-     * which is possible for objects with finalizers (See Section {@jls 12.6}
-     * of <cite>The Java Language Specification</cite>) that
-     * are implemented in ways that rely on ordering control for
-     * correctness.
+     * which is possible for objects with finalizers or that use Cleaners.
+     *
+     * <p>Memory consistency effects: Actions in a thread prior to calling
+     * reachabilityFence(x) happen-before any Reference to x is enqueued on a
+     * ReferenceQueue (such as happens when running a
+     * {@linkplain Cleaner.register cleaning action} for x).
      *
      * @apiNote
-     * Finalization may occur whenever the virtual machine detects that no
+     * Cleaning actions or finalization may occur whenever the virtual machine detects that no
      * reference to an object will ever be stored in the heap: The garbage
      * collector may reclaim an object even if the fields of that object are
      * still in use, so long as the object has otherwise become unreachable.

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -476,11 +476,16 @@ public abstract sealed class Reference<T>
      * <p> This method is invoked only by Java code; when the garbage collector
      * enqueues references it does so directly, without invoking this method.
      *
-     * <p>Memory consistency effects: Actions in a thread prior to successfully
+     * <p>Memory consistency effects: Actions in a thread prior to <b><i>successfully</i></b>
      * enqueueing a reference on a queue
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
      * the reference is removed from the queue by {@link ReferenceQueue#poll}
      * or {@link ReferenceQueue#remove}.
+     *
+     * @apiNote
+     * An unsuccessful enqueue() can occur if the GC collects the referent before
+     * the enqueue() call. {@link #reachabilityFence(Object)} can prevent this, by
+     * keeping the referent strongly-reachable.
      *
      * @return   {@code true} if this reference object was successfully
      *           enqueued; {@code false} if it was already enqueued or if
@@ -523,7 +528,8 @@ public abstract sealed class Reference<T>
      * the object to become unreachable; thus, the object is not
      * reclaimable by garbage collection at least until after the invocation of
      * this method. {@link Reference}s referring to the given object will not be
-     * enqueued on a {@link ReferenceQueue} until after invocation of this method.
+     * enqueued on a {@link ReferenceQueue} by the garbage collector until after
+     * invocation of this method.
      * Invocation of this method does not itself initiate reference processing,
      * garbage collection, or finalization.
      *

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -476,16 +476,21 @@ public abstract sealed class Reference<T>
      * <p> This method is invoked only by Java code; when the garbage collector
      * enqueues references it does so directly, without invoking this method.
      *
-     * <p>Memory consistency effects: Actions in a thread prior to <b><i>successfully</i></b>
-     * enqueueing a reference on a queue
+     * <p>Memory consistency effects: Actions in a thread prior to calling
+     * {@code enqueue} <b><i>successfully</i></b>
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
      * the reference is removed from the queue by {@link ReferenceQueue#poll}
      * or {@link ReferenceQueue#remove}.
      *
+     * <p>This method is invoked only by Java code; when the garbage collector
+     * enqueues references it does so directly, without invoking this method.
+     *
      * @apiNote
-     * An unsuccessful enqueue() can occur if the GC collects the referent before
-     * the enqueue() call. {@link #reachabilityFence(Object)} can prevent this, by
-     * keeping the referent strongly-reachable.
+     * Use of this method allows the registered queue's
+     * {@link ReferenceQueue#poll} and {@link ReferenceQueue#remove} methods
+     * to return this reference even though the referent is still strongly
+     * reachable. That is, before the referent has reached the expected
+     * reachability level.
      *
      * @return   {@code true} if this reference object was successfully
      *           enqueued; {@code false} if it was already enqueued or if

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -481,8 +481,8 @@ public abstract sealed class Reference<T>
     }
 
     /**
-     * Clears this reference object and adds it to the queue with which
-     * it is registered, if any.
+     * Clears this reference object, then attempts to add it to the queue with
+     * which it is registered, if any.
      *
      * <p>If this reference was already enqueued (by the garbage collector, or a
      * previous call to {@code enqueue}), this method is <b><i>not successful</i></b>,

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -518,26 +518,24 @@ public abstract sealed class Reference<T>
      * reclaimable by garbage collection at least until after the invocation of
      * this method. {@link Reference}s referring to the given object will not be
      * enqueued on a {@link ReferenceQueue} until after invocation of this method.
-     * Invocation of this method does not itself initiate garbage collection or
-     * finalization.
+     * Invocation of this method does not itself initiate reference processing,
+     * garbage collection, or finalization.
      *
      * <p> This method establishes an ordering for <em>strong reachability</em>
      * with respect to garbage collection.  It controls relations that are
      * otherwise only implicit in a program -- the reachability conditions
-     * triggering garbage collection.  This method is designed for use in
-     * uncommon situations of premature finalization where using
-     * {@code synchronized} blocks or methods, or using other synchronization
-     * facilities are not possible or do not provide the desired control.  This
-     * method is applicable only when reclamation may have visible effects,
-     * which is possible for objects with finalizers or that use Cleaners.
+     * triggering garbage collection.  This method is designed for use
+     * when reclamation may have visible effects,
+     * such as for objects with finalizers or that use Cleaner.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling
-     * reachabilityFence(x) happen-before any Reference to x is enqueued on a
-     * ReferenceQueue (such as happens when running a
-     * {@linkplain Cleaner.register cleaning action} for x).
+     * reachabilityFence(x)
+     * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
+     * any Reference to x is enqueued on a ReferenceQueue (such as happens when
+     * running a {@linkplain Cleaner#register cleaning action} for x).
      *
      * @apiNote
-     * Cleaning actions or finalization may occur whenever the virtual machine detects that no
+     * Reference processing or finalization may occur whenever the virtual machine detects that no
      * reference to an object will ever be stored in the heap: The garbage
      * collector may reclaim an object even if the fields of that object are
      * still in use, so long as the object has otherwise become unreachable.

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -531,8 +531,9 @@ public abstract sealed class Reference<T>
      * <p>Memory consistency effects: Actions in a thread prior to calling
      * reachabilityFence(x)
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * any Reference to x is enqueued on a ReferenceQueue (such as happens when
-     * running a {@linkplain Cleaner#register cleaning action} for x).
+     * any Reference to x is enqueued on a ReferenceQueue (as happens when a
+     * {@linkplain Cleaner#register cleaning action} for x runs on a
+     * {@linkplain Cleaner}'s thread).
      *
      * @apiNote
      * Reference processing or finalization may occur whenever the virtual machine detects that no

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -527,9 +527,9 @@ public abstract sealed class Reference<T>
      * regardless of any other actions of the program that might otherwise cause
      * the object to become unreachable; thus, the object is not
      * reclaimable by garbage collection at least until after the invocation of
-     * this method. {@link Reference}s referring to the given object will not be
-     * enqueued on a {@link ReferenceQueue} by the garbage collector until after
-     * invocation of this method.
+     * this method. References to the given object will not be cleared (or
+     * enqueued, if applicable) by the garbage collector until after invocation
+     * of this method.
      * Invocation of this method does not itself initiate reference processing,
      * garbage collection, or finalization.
      *
@@ -541,9 +541,10 @@ public abstract sealed class Reference<T>
      * such as for objects with finalizers or that use Cleaner.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling
-     * reachabilityFence(x)
+     * {@code reachabilityFence(x)}
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * the garbage collector enqueues any Reference to x on a ReferenceQueue.
+     * the garbage collector clears any reference to {code x}.
+
      *
      * @apiNote
      * Reference processing or finalization may occur whenever the virtual machine detects that no

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -481,8 +481,12 @@ public abstract sealed class Reference<T>
     }
 
     /**
-     * Clears this reference object and adds it to the queue with which
-     * it is registered, if any.
+     * Clears this reference object, then attempts to add it to the queue with
+     * which it is registered, if any.
+     *
+     * <p>If this reference was already enqueued (by the garbage collector, or a
+     * previous call to {@code enqueue}), this method is <b><i>not successful</i></b>,
+     * and returns false.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling
      * {@code enqueue} <b><i>successfully</i></b>
@@ -490,24 +494,15 @@ public abstract sealed class Reference<T>
      * the reference is removed from the queue by {@link ReferenceQueue#poll}
      * or {@link ReferenceQueue#remove}.
      *
-     * There is a potential race condition with the garbage collector.
-     * When this method is called, the garbage collector
-     * may already be in the process of (or already completed)
-     * enqueueing this reference.
-     *
-     * This can result in an
-     * <b><i></i></b>unsuccessful</i></b> {@code enqueue()}.
-     *
-     *
-     * Avoid this race by ensuring the referent remains strongly-reachable until after the call to clear(), using {@link #reachabilityFence(Object)} if necessary.
-     *
-     *
-     * <p> This method is invoked only by Java code; when the garbage collector
+     * <p>This method is invoked only by Java code; when the garbage collector
      * enqueues references it does so directly, without invoking this method.
      *
      * @apiNote
-     * Unexpected behavior can result if this method is called while the
-     * referent is still in use.
+     * Use of this method allows the registered queue's
+     * {@link ReferenceQueue#poll} and {@link ReferenceQueue#remove} methods
+     * to return this reference even though the referent is still strongly
+     * reachable. That is, before the referent has reached the expected
+     * reachability level.
      *
      * @return   {@code true} if this reference object was successfully
      *           enqueued; {@code false} if it was already enqueued or if

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -484,8 +484,8 @@ public abstract sealed class Reference<T>
      * Clears this reference object and adds it to the queue with which
      * it is registered, if any.
      *
-     * <p>Memory consistency effects: Actions in a thread prior to a reference
-     * being <b><i>successfully</i></b> enqueued
+     * <p>Memory consistency effects: Actions in a thread prior to calling
+     * {@code enqueue} <b><i>successfully</i></b>
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
      * the reference is removed from the queue by {@link ReferenceQueue#poll}
      * or {@link ReferenceQueue#remove}.

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -527,8 +527,9 @@ public abstract sealed class Reference<T>
      * regardless of any other actions of the program that might otherwise cause
      * the object to become unreachable; thus, the object is not
      * reclaimable by garbage collection at least until after the invocation of
-     * this method. References to the given object will not be enqueued on a
-     * queue by the garbage collector until after invocation of this method.
+     * this method. References to the given object will not be cleared (or
+     * enqueued, if applicable) by the garbage collector until after invocation
+     * of this method.
      * Invocation of this method does not itself initiate reference processing,
      * garbage collection, or finalization.
      *
@@ -542,7 +543,7 @@ public abstract sealed class Reference<T>
      * <p>Memory consistency effects: Actions in a thread prior to calling
      * {@code reachabilityFence(x)}
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * the garbage collector enqueues any reference to {code x}.
+     * the garbage collector clears any reference to {code x}.
      *
      * @apiNote
      * Reference processing or finalization may occur whenever the virtual machine detects that no

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -541,9 +541,9 @@ public abstract sealed class Reference<T>
      * such as for objects with finalizers or that use Cleaner.
      *
      * <p>Memory consistency effects: Actions in a thread prior to calling
-     * reachabilityFence(x)
+     * {@code reachabilityFence(x)}
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * the garbage collector enqueues any Reference to {code x} on a ReferenceQueue.
+     * the garbage collector enqueues any reference to {code x} on a queue.
      *
      * @apiNote
      * Reference processing or finalization may occur whenever the virtual machine detects that no

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -483,9 +483,9 @@ public abstract sealed class Reference<T>
      * or {@link ReferenceQueue#remove}.
      *
      * @apiNote
-     * An unsuccessful enqueue() can occur if the GC collects the referent before
-     * the enqueue() call. {@link #reachabilityFence(Object)} can prevent this, by
-     * keeping the referent strongly-reachable.
+     * An unsuccessful {@code enqueue()} can occur if the GC collects the referent
+     * before the {@code enqueue()} call. {@link #reachabilityFence(Object)} can
+     * prevent this, by keeping the referent strongly-reachable.
      *
      * @return   {@code true} if this reference object was successfully
      *           enqueued; {@code false} if it was already enqueued or if

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -543,7 +543,7 @@ public abstract sealed class Reference<T>
      * <p>Memory consistency effects: Actions in a thread prior to calling
      * reachabilityFence(x)
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * the garbage collector enqueues any Reference to x on a ReferenceQueue.
+     * the garbage collector enqueues any Reference to {code x} on a ReferenceQueue.
      *
      * @apiNote
      * Reference processing or finalization may occur whenever the virtual machine detects that no

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -476,8 +476,8 @@ public abstract sealed class Reference<T>
      * <p> This method is invoked only by Java code; when the garbage collector
      * enqueues references it does so directly, without invoking this method.
      *
-     * <p>Memory consistency effects: Actions in a thread prior to <b><i>successfully</i></b>
-     * enqueueing a reference on a queue
+     * <p>Memory consistency effects: Actions in a thread prior to a reference
+     * being <b><i>successfully</i></b> enqueued
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
      * the reference is removed from the queue by {@link ReferenceQueue#poll}
      * or {@link ReferenceQueue#remove}.
@@ -542,7 +542,7 @@ public abstract sealed class Reference<T>
      * <p>Memory consistency effects: Actions in a thread prior to calling
      * {@code reachabilityFence(x)}
      * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
-     * the garbage collector enqueues any reference to {code x} on a queue.
+     * the garbage collector enqueues any reference to {code x}.
      *
      * @apiNote
      * Reference processing or finalization may occur whenever the virtual machine detects that no

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -485,7 +485,7 @@ public abstract sealed class Reference<T>
      * @apiNote
      * An unsuccessful {@code enqueue()} can occur if the GC collects the referent
      * before the {@code enqueue()} call. {@link #reachabilityFence(Object)} can
-     * prevent this, by keeping the referent strongly-reachable.
+     * prevent this, if used to keep the referent strongly-reachable.
      *
      * @return   {@code true} if this reference object was successfully
      *           enqueued; {@code false} if it was already enqueued or if

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -527,9 +527,8 @@ public abstract sealed class Reference<T>
      * regardless of any other actions of the program that might otherwise cause
      * the object to become unreachable; thus, the object is not
      * reclaimable by garbage collection at least until after the invocation of
-     * this method. {@link Reference}s referring to the given object will not be
-     * enqueued on a {@link ReferenceQueue} by the garbage collector until after
-     * invocation of this method.
+     * this method. References to the given object will not be enqueued on a
+     * queue by the garbage collector until after invocation of this method.
      * Invocation of this method does not itself initiate reference processing,
      * garbage collection, or finalization.
      *

--- a/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -36,13 +36,11 @@ import jdk.internal.misc.VM;
  * garbage collector after the appropriate reachability changes are detected.
  *
  * This interaction between the garbage collector and ReferenceQueues has
- * a memory consistency effect: Actions in a thread that happen while a Reference's
+ * a memory consistency effect. Actions in a thread preceding a call to
+ * {@link Reference.reachabilityFence} on a Reference's
  * <a href="../package-summary.html>referent</a>
- * is still strongly-reachable
  * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
- * any References to that referent are enqueued on a ReferenceQueue. A thread
- * can ensure this reachability by calling {@link Reference.reachabilityFence}
- * on the referent.
+ * any References to that referent become available on a ReferenceQueue.
 
  * @param <T> the type of the reference object
  *

--- a/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -36,7 +36,7 @@ import jdk.internal.misc.VM;
  * garbage collector after the appropriate reachability changes are detected.
  *
  * <p>Memory consistency effects: The enqueueing of a reference on a
- * queue (by the garbage collector, or by a call to {@link Reference#enqueue})
+ * queue (by the garbage collector, or by a successful call to {@link Reference#enqueue})
  * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
  * the reference is removed from the queue by {@link ReferenceQueue#poll} or
  * {@link ReferenceQueue#remove}.

--- a/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -34,6 +34,16 @@ import jdk.internal.misc.VM;
 /**
  * Reference queues, to which registered reference objects are appended by the
  * garbage collector after the appropriate reachability changes are detected.
+ *
+ * This interaction between the garbage collector and ReferenceQueues has
+ * a memory consistency effect: Actions in a thread that happen while a Reference's
+ * <a href="../package-summary.html>referent</a>
+ * is still strongly-reachable
+ * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
+ * any References to that referent are enqueued on a ReferenceQueue. A thread
+ * can ensure this reachability by calling {@link Reference.reachabilityFence}
+ * on the referent.
+
  * @param <T> the type of the reference object
  *
  * @author   Mark Reinhold

--- a/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -180,6 +180,12 @@ public class ReferenceQueue<T> {
      * available without further delay then it is removed from the queue and
      * returned.  Otherwise this method immediately returns {@code null}.
      *
+     * @apiNote
+     * If the returned reference was added to this queue by a call to
+     * {@link Reference#enqueue()} instead of by the garbage collector, its
+     * former referent (which has since been cleared) could still be strongly
+     * reachable.
+     *
      * @return  A reference object, if one was immediately available,
      *          otherwise {@code null}
      */
@@ -200,6 +206,12 @@ public class ReferenceQueue<T> {
      *
      * <p> This method does not offer real-time guarantees: It schedules the
      * timeout as if by invoking the {@link Object#wait(long)} method.
+     *
+     * @apiNote
+     * If the returned reference was added to this queue by a call to
+     * {@link Reference#enqueue()} instead of by the garbage collector, its
+     * former referent (which has since been cleared) could still be strongly
+     * reachable.
      *
      * @param  timeout  If positive, block for up to {@code timeout}
      *                  milliseconds while waiting for a reference to be
@@ -231,6 +243,12 @@ public class ReferenceQueue<T> {
     /**
      * Removes the next reference object in this queue, blocking until one
      * becomes available.
+     *
+     * @apiNote
+     * If the returned reference was added to this queue by a call to
+     * {@link Reference#enqueue()} instead of by the garbage collector, its
+     * former referent (which has since been cleared) could still be strongly
+     * reachable.
      *
      * @return A reference object, blocking until one becomes available
      * @throws  InterruptedException  If the wait is interrupted

--- a/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -35,13 +35,12 @@ import jdk.internal.misc.VM;
  * Reference queues, to which registered reference objects are appended by the
  * garbage collector after the appropriate reachability changes are detected.
  *
- * This interaction between the garbage collector and ReferenceQueues has
- * a memory consistency effect. Actions in a thread preceding a call to
- * {@link Reference.reachabilityFence} on a Reference's
- * <a href="../package-summary.html>referent</a>
- * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happen-before</i></a>
- * any References to that referent become available on a ReferenceQueue.
-
+ * <p>Memory consistency effects: The enqueueing of a reference on a
+ * queue (by the garbage collector, or by a call to {@link Reference#enqueue}
+ * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
+ * the reference is removed from the queue by {@link ReferenceQueue#poll} or
+ * {@link ReferenceQueue#remove}.
+ *
  * @param <T> the type of the reference object
  *
  * @author   Mark Reinhold

--- a/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -36,7 +36,7 @@ import jdk.internal.misc.VM;
  * garbage collector after the appropriate reachability changes are detected.
  *
  * <p>Memory consistency effects: The enqueueing of a reference on a
- * queue (by the garbage collector, or by a call to {@link Reference#enqueue}
+ * queue (by the garbage collector, or by a call to {@link Reference#enqueue})
  * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
  * the reference is removed from the queue by {@link ReferenceQueue#poll} or
  * {@link ReferenceQueue#remove}.

--- a/src/java.base/share/classes/java/lang/ref/package-info.java
+++ b/src/java.base/share/classes/java/lang/ref/package-info.java
@@ -102,10 +102,9 @@
  *
  * <li> Actions in a thread prior to calling
  * {@link Reference#reachabilityFence Reference.reachabilityFence(x)}
- * <i>happen-before</i> the garbage collector enqueues any reference to {@code x}
- * on a queue.</li>
+ * <i>happen-before</i> the garbage collector enqueues any reference to {@code x}.</li>
  *
- * <li> The enqueueing of a reference on a queue (by the garbage collector, or
+ * <li> The enqueueing of a reference (by the garbage collector, or
  * by a successful call to {@link Reference#enqueue}) <i>happens-before</i>
  * the reference is removed from the queue by {@link ReferenceQueue#poll} or
  * {@link ReferenceQueue#remove}.</li>

--- a/src/java.base/share/classes/java/lang/ref/package-info.java
+++ b/src/java.base/share/classes/java/lang/ref/package-info.java
@@ -94,7 +94,8 @@
  * access methods.
  *
  * <h3>Memory Consistency Properties</h3>
- * Certain interactions with the garbage collector and reference queues form
+ * Certain interactions between the garbage collector, references, and reference
+ * queues form
  * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
  * relationships:
  *
@@ -102,7 +103,10 @@
  *
  * <li> Actions in a thread prior to calling
  * {@link Reference#reachabilityFence Reference.reachabilityFence(x)}
- * <i>happen-before</i> the garbage collector enqueues any reference to {@code x}.</li>
+ * <i>happen-before</i> the garbage collector clears any reference to {@code x}.</li>
+ *
+ * <li>The clearing of a reference by the garbage collector <i>happens-before</i>
+ * the garbage collector enqueues the reference.</li>
  *
  * <li> The enqueueing of a reference (by the garbage collector, or
  * by a successful call to {@link Reference#enqueue}) <i>happens-before</i>

--- a/src/java.base/share/classes/java/lang/ref/package-info.java
+++ b/src/java.base/share/classes/java/lang/ref/package-info.java
@@ -102,7 +102,7 @@
  *
  * <li> Actions in a thread prior to calling
  * {@link Reference#reachabilityFence Reference.reachabilityFence(x)}
- * <i>happen-before</i> the garbage collector enqueues a reference to {@code x}
+ * <i>happen-before</i> the garbage collector enqueues any reference to {@code x}
  * on a queue.</li>
  *
  * <li> The enqueueing of a reference on a queue (by the garbage collector, or

--- a/src/java.base/share/classes/java/lang/ref/package-info.java
+++ b/src/java.base/share/classes/java/lang/ref/package-info.java
@@ -102,13 +102,14 @@
  *
  * <li> Actions in a thread prior to calling
  * {@link Reference#reachabilityFence Reference.reachabilityFence(x)}
- * <i>happen-before</i> the garbage collector enqueues a reference to x on a
- * queue.</li>
+ * <i>happen-before</i> the garbage collector enqueues a reference to {@code x}
+ * on a queue.</li>
  *
  * <li> The enqueueing of a reference on a queue (by the garbage collector, or
- * by a successfull {@link Reference#enqueue}) <i>happens-before</i> the reference
- * is removed from the queue by {@link ReferenceQueue#poll} or
+ * by a successful call to {@link Reference#enqueue}) <i>happens-before</i>
+ * the reference is removed from the queue by {@link ReferenceQueue#poll} or
  * {@link ReferenceQueue#remove}.</li>
+ *
  * </ul>
  *
  * <a id="reachability"></a>

--- a/src/java.base/share/classes/java/lang/ref/package-info.java
+++ b/src/java.base/share/classes/java/lang/ref/package-info.java
@@ -93,6 +93,24 @@
  * structure, this check will add little overhead to the hashtable
  * access methods.
  *
+ * <h3>Memory Consistency Properties</h3>
+ * Certain interactions with the garbage collector and reference queues form
+ * <a href="{@docRoot}/java.base/java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
+ * relationships:
+ *
+ * <ul>
+ *
+ * <li> Actions in a thread prior to calling
+ * {@link Reference#reachabilityFence Reference.reachabilityFence(x)}
+ * <i>happen-before</i> the garbage collector enqueues a reference to x on a
+ * queue.</li>
+ *
+ * <li> The enqueueing of a reference on a queue (by the garbage collector, or
+ * by a successfull {@link Reference#enqueue}) <i>happens-before</i> the reference
+ * is removed from the queue by {@link ReferenceQueue#poll} or
+ * {@link ReferenceQueue#remove}.</li>
+ * </ul>
+ *
  * <a id="reachability"></a>
  * <h3>Reachability</h3>
  *


### PR DESCRIPTION
 Classes in the `java.lang.ref` package would benefit from an update to bring the spec in line with how the VM already behaves. The changes would focus on _happens-before_ edges at some key points during reference processing.

A couple key things we want to be able to say are:
* `Reference.reachabilityFence(x)` _happens-before_ reference processing occurs for 'x'.
* `Cleaner.register()` _happens-before_ the Cleaner thread runs the registered cleaning action.

This will bring Cleaner in line (or close) with the memory visibility guarantees made for finalizers in [JLS 17.4.5](https://docs.oracle.com/javase/specs/jls/se18/html/jls-17.html#jls-17.4.5):
_"There is a happens-before edge from the end of a constructor of an object to the start of a finalizer (§12.6) for that object."_