### PR TITLE
8349107: Remove RMI finalizers

### DIFF
--- a/src/java.rmi/share/classes/sun/rmi/log/LogInputStream.java
+++ b/src/java.rmi/share/classes/sun/rmi/log/LogInputStream.java
@@ -124,12 +124,4 @@ class LogInputStream extends InputStream {
     public void close() {
         length = 0;
     }
-
-    /**
-     * Closes the stream when garbage is collected.
-     */
-    @SuppressWarnings("removal")
-    protected void finalize() throws IOException {
-        close();
-    }
 }

--- a/src/jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContext.java
+++ b/src/jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContext.java
@@ -100,11 +100,6 @@ public class RegistryContext implements Context, Referenceable {
         reference = ctx.reference;
     }
 
-    @SuppressWarnings("removal")
-    protected void finalize() {
-        close();
-    }
-
     public Object lookup(Name name) throws NamingException {
         if (name.isEmpty()) {
             return (new RegistryContext(this));

--- a/src/jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContext.java
+++ b/src/jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContext.java
@@ -552,11 +552,6 @@ class BindingEnumeration implements NamingEnumeration<Binding> {
         nextName = 0;
     }
 
-    @SuppressWarnings("removal")
-    protected void finalize() {
-        ctx.close();
-    }
-
     public boolean hasMore() {
         if (nextName >= names.length) {
             ctx.close();
@@ -593,8 +588,7 @@ class BindingEnumeration implements NamingEnumeration<Binding> {
         }
     }
 
-    @SuppressWarnings("deprecation")
     public void close () {
-        finalize();
+        ctx.close();
     }
 }


### PR DESCRIPTION
3 finalizers in RMI code can be removed, as they do not perform meaningful cleanup.

**`jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContext`**

`RegistryContext.finalize()` just calls `close()`. The `close()` method does not perform any cleanup per se, but rather "helps the garbage collector" by setting `environment` and `registry` to `null`.


**`jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContext.BindingEnumeration`**

`BindingEnumeration.finalize()` simply calls `close()` on the `ctx` field, itself a `RegistryContext` (and `close()` just "helps the GC.")


**`src/java.rmi/share/classes/sun/rmi/log/LogInputStream`**

`LogInputStream` tracks its length with an int field, `length`. If `length` ever becomes == 0, `LogInputStream`'s methods will return without doing anything.

The finalizer calls `close()`, which just sets length = 0.

By the time a `LogInputStream` becomes unreachable and is finalized, it's a moot point whether length == 0, as no more methods can be called.
If anything, this finalizer could cause a bug. If a `LogInputStream` were to became unreachable while a method were still running, the finalizer could set the length to 0 while method code is still running and expecting a length != 0.
It's possible that there is a very long standing bug that `close()` should be calling `in.close()`, in which case this evaluation will need to be revisited.